### PR TITLE
Updates and bug fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "woganmay/domo-php",
     "description": "Use Domo.com APIs with PHP",
     "require": {
-        "guzzlehttp/guzzle": "6.2.0",
+        "guzzlehttp/guzzle": "6.3.0",
         "ext-curl": "*"
     },
     "license": "MIT",

--- a/src/DataSet.php
+++ b/src/DataSet.php
@@ -155,7 +155,7 @@ class DataSet
     {
         $response = $this->DomoAPIClient->WebClient->delete("/v1/datasets/$id", [
             'headers' => [
-                'Authorization' => 'Bearer '.$this->getToken(),
+                'Authorization' => 'Bearer '.$this->DomoAPIClient->getToken(),
             ],
         ]);
 
@@ -216,6 +216,7 @@ class DataSet
         // Handle server response
         switch ($response->getStatusCode()) {
             case 200:
+            case 204:
                 // Resource Updated
                 return json_decode($response->getBody());
             default:


### PR DESCRIPTION
Updating to Guzzle 6.3.0 fixes an upstream issue with Composer when using this library with Drupal 8.
The delete method was attempting to access the token in the wrong place.
The import command response is a 204 not a 200?